### PR TITLE
Add Portal for Modal to move it to modal-root

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,5 +14,6 @@
   </head>
   <body>
     <div id="root"></div>
+    <div id="modal-root"></div>
   </body>
 </html>

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -1,30 +1,49 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import ReactDOM from 'react-dom';
 import './Modal.css';
 
 const Modal = ({ header, onClose, children, footer }) => {
-  return (
-    <div className="modal-overlay" onClick={onClose}>
-      <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+  // Close on Escape key
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [onClose]);
+
+  // Modal content
+  const modalContent = (
+    <div
+      className="modal-overlay"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+    >
+      <div
+        className="modal-content"
+        onClick={(e) => e.stopPropagation()}
+        role="document"
+        aria-labelledby="modal-title"
+      >
         {header && (
-          <h4 className="modal-title">
+          <h4 id="modal-title" className="modal-title">
             {header}
           </h4>
         )}
-
-        <div className="modal-scrollable-content">
-          {children}
-        </div>
-
+        <div className="modal-scrollable-content">{children}</div>
         <div className="modal-footer">
-          {footer ? (
-            footer
-          ) : (
-            <button className="close-btn" onClick={onClose}>Close</button>
-          )}
+          {footer || <button className="close-btn" onClick={onClose}>Close</button>}
         </div>
       </div>
     </div>
   );
+
+  return ReactDOM.createPortal(modalContent, document.getElementById('modal-root'));
 };
 
 export default Modal;


### PR DESCRIPTION
Because previously, we render Modal in a Component (at root), so when we in middle of 2 section, the part is in next section can not be interacted.

To fix it, I added a Portal to Modal and render it to outside root, it's modal-root, so now we can interact to Modal directly even that modal is placed in 2 sections.